### PR TITLE
Change the —security-group-id to match the environmental variable being set in the script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ deploy-ami:
 	--instance-type m3.medium \
 	--iam-instance-profile "Name=${DEPLOY_ROLE}" \
 	--key-name ${DEPLOY_KEY_NAME} \
-	--security-group-ids ${DEPLOY_SG} \
+	--security-group-ids ${DEPLOY_SECURITY_GROUP} \
 	--subnet-id ${DEPLOY_SUBNET_ID} \
 	--region ${DEPLOY_REGION}
 

--- a/vars.yml
+++ b/vars.yml
@@ -1,6 +1,6 @@
 ---
 zookeeper:
-  version: 3.4.6
+  version: 3.4.8
   dir: /opt/zookeeper
   data_dir: /opt/zookeeper/data
   log_dir: /opt/zookeeper/log
@@ -13,7 +13,7 @@ zookeeper:
   group: zookeeper
 
 exhibitor:
-  version: 1.5.5
+  version: 1.5.6
   dir: /opt/exhibitor
   data_dir: /opt/exhibitor/data
   log_dir: /opt/exhibitor/log


### PR DESCRIPTION
The environmental variable being referenced by the Makefile didn't match the environmental variable being set in the shell script.
